### PR TITLE
Update track api, rename mfa to getUser

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@authsignal/node",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "types": "dist/index.d.ts",
   "keywords": [
     "authsignal",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,16 +1,15 @@
-export interface AuthsignalServerConstructor {
+export interface AuthsignalConstructor {
   secret: string;
   apiBaseUrl?: string;
-}
-
-export interface MfaRequest {
-  userId: string;
   redirectUrl?: string;
 }
 
-export interface MfaResponse {
+export interface UserRequest {
+  userId: string;
+}
+
+export interface UserResponse {
   isEnrolled: boolean;
-  url: string;
 }
 
 export interface TrackRequest {
@@ -23,12 +22,15 @@ export interface TrackRequest {
   userAgent?: string;
   deviceId?: string;
   custom?: object;
+  redirectToSettings?: boolean;
 }
 
 export interface TrackResponse {
   state: UserActionState;
   idempotencyKey: string;
   ruleIds: string[];
+  url: string;
+  isEnrolled: boolean;
   challengeUrl?: string;
 }
 


### PR DESCRIPTION
- Update track api to include `redirectToSettings` field on request, `url` and `isEnrolled` fields on response
- Rename `mfa` to `getUser` and drop `redirectUrl` field
- Allow passing `redirectUrl` in constructor