### PR TITLE
Add methods to initiate sms/email challenge

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@authsignal/node",
-  "version": "2.4.3",
+  "version": "2.5.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/src/authsignal.ts
+++ b/src/authsignal.ts
@@ -28,6 +28,13 @@ import {
   QueryUsersResponse,
   QueryUserActionsRequest,
   QueryUserActionsResponse,
+  ClaimChallengeRequest,
+  ClaimChallengeResponse,
+  ChallengeRequest,
+  ChallengeResponse,
+  VerifyRequest,
+  VerifyResponse,
+  VerificationMethod,
 } from "./types";
 import {Webhook} from "./webhook";
 
@@ -249,6 +256,20 @@ export class Authsignal {
     }
   }
 
+  public async claimChallenge(request: ClaimChallengeRequest): Promise<ClaimChallengeResponse> {
+    const url = `${this.apiUrl}/claim`;
+
+    const config = this.getRequestConfig();
+
+    try {
+      const response = await axios.post<ClaimChallengeResponse>(url, request, config);
+
+      return response.data;
+    } catch (error) {
+      throw mapToAuthsignalError(error);
+    }
+  }
+
   public async getAction(request: GetActionRequest): Promise<GetActionResponse> {
     const {userId, action, idempotencyKey} = request;
 
@@ -302,6 +323,36 @@ export class Authsignal {
 
     try {
       const response = await axios.patch<ActionAttributes>(url, attributes, config);
+
+      return response.data;
+    } catch (error) {
+      throw mapToAuthsignalError(error);
+    }
+  }
+
+  public async challenge(request: ChallengeRequest): Promise<ChallengeResponse> {
+    const url = `${this.apiUrl}/challenge/${request.email ? "email" : "sms"}`;
+
+    const config = this.getRequestConfig();
+
+    try {
+      const response = await axios.post<ChallengeResponse>(url, request, config);
+
+      return response.data;
+    } catch (error) {
+      throw mapToAuthsignalError(error);
+    }
+  }
+
+  public async verify(request: VerifyRequest): Promise<VerifyResponse> {
+    const {verificationMethod, ...data} = request;
+
+    const url = `${this.apiUrl}/verify/${verificationMethod === VerificationMethod.EMAIL_OTP ? "email" : "sms"}`;
+
+    const config = this.getRequestConfig();
+
+    try {
+      const response = await axios.post<VerifyResponse>(url, data, config);
 
       return response.data;
     } catch (error) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,6 +165,15 @@ export interface ValidateChallengeResponse {
   error?: string;
 }
 
+export interface ClaimChallengeRequest {
+  challengeId: string;
+  userId: string;
+}
+
+export interface ClaimChallengeResponse {
+  token: string;
+}
+
 export interface DeleteAuthenticatorRequest {
   userId: string;
   userAuthenticatorId: string;
@@ -189,6 +198,27 @@ export interface GetChallengeRequest {
 
 export interface GetChallengeResponse {
   challengeId?: string;
+}
+
+export interface ChallengeRequest {
+  action: string;
+  email?: string;
+  phoneNumber?: string;
+  smsChannel?: SmsChannel;
+}
+
+export interface ChallengeResponse {
+  challengeId: string;
+}
+
+export interface VerifyRequest {
+  challengeId: string;
+  verificationMethod: VerificationMethod.SMS | VerificationMethod.EMAIL_OTP;
+  verificationCode: string;
+}
+
+export interface VerifyResponse {
+  isVerified: boolean;
 }
 
 export enum UserActionState {
@@ -290,6 +320,11 @@ export interface Rule {
   ruleId: string;
   name: string;
   description?: string;
+}
+
+export enum SmsChannel {
+  WHATSAPP = "WHATSAPP",
+  DEFAULT = "DEFAULT",
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
### New Features
- Added new methods for initiating and verifying an SMS or email OTP challenge in scenarios where a persistent user ID is not known yet
- Added a method to claim an SMS/email challenge on behalf of a user after it has been verified, associating it with a persistent user ID

### Checklist
- [ ] Version bumped