### PR TITLE
Add EMAIL channel support to call start endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@authsignal/node",
-  "version": "2.14.0",
+  "version": "2.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@authsignal/node",
-      "version": "2.14.0",
+      "version": "2.20.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@authsignal/node",
-  "version": "2.19.0",
+  "version": "2.20.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/src/call-connect.ts
+++ b/src/call-connect.ts
@@ -71,24 +71,30 @@ export class CallConnect {
 
 export type StartCallRequest = {
   referenceId: string;
-  phoneNumber: string;
+  phoneNumber?: string;
+  country?: string;
   userId?: string;
   username?: string;
   channel?: CallConnectMessageChannel;
   email?: string;
   locale?: string;
+  actionCode?: string;
 };
 
 export type StartCallResponse = {
   messageId?: string;
-  status?: string;
-  error?: string;
   channel?: CallConnectMessageChannel;
+  phoneNumber?: string;
+  email?: string;
+  error?: string;
+  errorCode?: string;
+  errorDescription?: string;
 };
 
 export enum CallConnectMessageChannel {
   "WHATSAPP" = "WHATSAPP",
   "SMS" = "SMS",
+  "EMAIL" = "EMAIL",
 }
 
 export type FinishCallRequest = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,3 @@
 export const DEFAULT_API_URL = "https://api.authsignal.com/v1";
 
-export const VERSION = "2.19.10";
+export const VERSION = "2.20.0";


### PR DESCRIPTION
### New Features
- Add EMAIL channel option to CallConnectMessageChannel enum
- Make phoneNumber optional in StartCallRequest (required for SMS/WhatsApp only)
- Add country field for phone number formatting
- Add actionCode field (defaults to "call")

### Updates
- Update StartCallResponse to include phoneNumber and email fields
- Replace status field with errorCode and errorDescription for better error handling

### Checklist
- [x] Version bumped to 2.20.0