### PR TITLE
Add veriffSessionId to ValidateChallengeResponse

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@authsignal/node",
-  "version": "2.20.0",
+  "version": "2.21.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/src/types.ts
+++ b/src/types.ts
@@ -166,6 +166,7 @@ export interface ValidateChallengeResponse {
   action?: string;
   idempotencyKey?: string;
   verificationMethod?: VerificationMethod;
+  veriffSessionId?: string;
   error?: string;
 }
 

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -28,7 +28,7 @@ describe("authsignal client tests", () => {
       userId,
       attributes: {
         verificationMethod: VerificationMethod.SMS,
-        phoneNumber: "+6427000000",
+        phoneNumber: "+64270000000",
       },
     };
 
@@ -88,7 +88,7 @@ describe("authsignal client tests", () => {
       userId,
       attributes: {
         verificationMethod: VerificationMethod.SMS,
-        phoneNumber: "+6427000000",
+        phoneNumber: "+64270000000",
       },
     };
 
@@ -128,7 +128,7 @@ describe("authsignal client tests", () => {
       userId,
       attributes: {
         verificationMethod: VerificationMethod.SMS,
-        phoneNumber: "+6427000000",
+        phoneNumber: "+64270000000",
       },
     };
 


### PR DESCRIPTION
## Summary

- Adds `veriffSessionId?: string` to `ValidateChallengeResponse`
- Bumps version to `2.21.0`.
