### PR TITLE
Support structured webhook data and log event batches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@authsignal/node",
-  "version": "2.20.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@authsignal/node",
-      "version": "2.20.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@authsignal/node",
-  "version": "2.21.0",
+  "version": "3.0.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -12,6 +12,82 @@ export class Webhook {
   }
 
   constructEvent(payload: WebhookPayload, signature: string, tolerance: number = DEFAULT_TOLERANCE): WebhookEvent {
+    this.verifySignature(payload, signature, tolerance);
+
+    const parsedPayload = this.parsePayload(payload);
+
+    if ("records" in parsedPayload) {
+      throw new InvalidPayloadError("Payload is a batch of log events. Use constructLogEventBatch instead.");
+    }
+
+    this.validateEvent(parsedPayload, "data");
+
+    return parsedPayload as WebhookEvent;
+  }
+
+  constructLogEventBatch(
+    payload: WebhookPayload,
+    signature: string,
+    tolerance: number = DEFAULT_TOLERANCE
+  ): WebhookEventBatch {
+    this.verifySignature(payload, signature, tolerance);
+
+    const parsedPayload = this.parsePayload(payload);
+
+    if (!("records" in parsedPayload) || !Array.isArray(parsedPayload.records)) {
+      throw new InvalidPayloadError("Payload format is invalid. Expected a 'records' array.");
+    }
+
+    for (const event of parsedPayload.records) {
+      this.validateEvent(event, "record");
+    }
+
+    return parsedPayload as WebhookEventBatch;
+  }
+
+  private parsePayload(payload: WebhookPayload): Record<string, unknown> {
+    try {
+      const parsedPayload = JSON.parse(payload) as unknown;
+
+      if (!parsedPayload || typeof parsedPayload !== "object" || Array.isArray(parsedPayload)) {
+        throw new InvalidPayloadError("Payload format is invalid.");
+      }
+
+      return parsedPayload as Record<string, unknown>;
+    } catch (error) {
+      if (error instanceof InvalidPayloadError) {
+        throw error;
+      }
+
+      throw new InvalidPayloadError("Payload format is invalid.");
+    }
+  }
+
+  private validateEvent(event: unknown, contentField: "data" | "record"): void {
+    if (!event || typeof event !== "object" || Array.isArray(event)) {
+      throw new InvalidPayloadError("Payload format is invalid.");
+    }
+
+    const fields = event as Record<string, unknown>;
+
+    if (typeof fields.version !== "number" || fields.version <= 0) {
+      throw new InvalidPayloadError("Payload is missing required field 'version'.");
+    }
+
+    for (const field of ["type", "id", "source", "time", "tenantId"]) {
+      const value = fields[field];
+      if (typeof value !== "string" || value.trim().length === 0) {
+        throw new InvalidPayloadError(`Payload is missing required field '${field}'.`);
+      }
+    }
+
+    const content = fields[contentField];
+    if (!content || typeof content !== "object" || Array.isArray(content)) {
+      throw new InvalidPayloadError(`Payload is missing required field '${contentField}'.`);
+    }
+  }
+
+  private verifySignature(payload: WebhookPayload, signature: string, tolerance: number): void {
     const parsedSignature = this.parseSignature(signature);
 
     const secondsSinceEpoch = Math.round(Date.now() / 1000);
@@ -38,8 +114,6 @@ export class Webhook {
     if (!match) {
       throw new InvalidSignatureError("Signature mismatch.");
     }
-
-    return JSON.parse(payload) as WebhookEvent;
   }
 
   parseSignature(value: string): SignatureHeaderData {
@@ -85,14 +159,34 @@ export type WebhookEvent = {
   data: WebhookEventData;
 };
 
-export type WebhookEventData = Record<string, string>;
+export type WebhookEventData = Record<string, unknown>;
+
+export type WebhookLogEvent = {
+  version: number;
+  type: string;
+  id: string;
+  source: string;
+  time: string;
+  tenantId: string;
+  record: WebhookEventData;
+};
+
+export type WebhookEventBatch = {
+  records: WebhookLogEvent[];
+};
 
 interface SignatureHeaderData {
   signatures: string[];
   timestamp: number;
 }
 
-class InvalidSignatureError extends Error {
+export class InvalidSignatureError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+export class InvalidPayloadError extends Error {
   constructor(message: string) {
     super(message);
   }

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -1,22 +1,19 @@
+import {createHmac} from "crypto";
 import {test, expect, describe} from "vitest";
-import "dotenv/config";
 
 import {Authsignal} from "../src";
 
-const apiUrl = process.env.AUTHSIGNAL_API_URL;
-const apiSecretKey = process.env.AUTHSIGNAL_API_SECRET_KEY;
+const apiSecretKey = "test-secret-key";
+const client = new Authsignal({apiSecretKey, apiUrl: "https://api.authsignal.com/v1"});
 
-if (!apiUrl) {
-  console.log("AUTHSIGNAL_API_URL is undefined in env");
-  process.exit(1);
-}
+const createSignature = (payload: string, timestamp = Math.floor(Date.now() / 1000)): string => {
+  const signature = createHmac("sha256", apiSecretKey)
+    .update(`${timestamp}.${payload}`)
+    .digest("base64")
+    .replace("=", "");
 
-if (!apiSecretKey) {
-  console.log("AUTHSIGNAL_API_SECRET_KEY is undefined in env");
-  process.exit(1);
-}
-
-const client = new Authsignal({apiSecretKey, apiUrl});
+  return `t=${timestamp},v2=${signature}`;
+};
 
 describe("authsignal webhook tests", () => {
   test("test invalid signature format", async () => {
@@ -83,12 +80,7 @@ describe("authsignal webhook tests", () => {
       },
     });
 
-    // Ignore tolerance window
-    const tolerance = -1;
-
-    const signature = "t=1740016316,v2=NwFcIT68pK7g+m365Jj4euXj/ke3GSnkTpMPcRVi5q4";
-
-    const event = client.webhook.constructEvent(payload, signature, tolerance);
+    const event = client.webhook.constructEvent(payload, createSignature(payload));
 
     expect(event).toBeDefined();
 
@@ -115,14 +107,79 @@ describe("authsignal webhook tests", () => {
       },
     });
 
-    // Ignore tolerance window
-    const tolerance = -1;
+    const validSignature = createSignature(payload);
+    const signature = `${validSignature},v2=invalid_signature`;
 
-    const signature =
-      "t=1740016037,v2=zI5rg1XJtKH8dXTX9VCSwy07qTPJliXkK9ppgNjmzqw,v2=KMg8mXXGO/SmNNmcszKXI4UaEVHLc21YNWthHfispQo";
-
-    const event = client.webhook.constructEvent(payload, signature, tolerance);
+    const event = client.webhook.constructEvent(payload, signature);
 
     expect(event).toBeDefined();
+  });
+
+  test("test event with custom variables", () => {
+    const payload = JSON.stringify({
+      version: 1,
+      id: "bc1598bc-e5d6-4c69-9afb-1a6fe3469d6e",
+      source: "https://authsignal.com",
+      time: "2025-02-20T01:51:56.070Z",
+      tenantId: "7752d28e-e627-4b1b-bb81-b45d68d617bc",
+      type: "sms.created",
+      data: {
+        actionCode: "smsVerify",
+        customVariables: {
+          action_journeyType: "ForgotChangePassword",
+          retryCount: 2,
+          isRecovery: true,
+          channels: ["sms", "email"],
+        },
+      },
+    });
+
+    const event = client.webhook.constructEvent(payload, createSignature(payload));
+    const customVariables = event.data.customVariables as Record<string, unknown>;
+
+    expect(customVariables.action_journeyType).toEqual("ForgotChangePassword");
+    expect(customVariables.retryCount).toEqual(2);
+    expect(customVariables.isRecovery).toEqual(true);
+    expect(customVariables.channels).toEqual(["sms", "email"]);
+  });
+
+  test("test log event batch", () => {
+    const payload = JSON.stringify({
+      records: [
+        {
+          version: 1,
+          id: "bc1598bc-e5d6-4c69-9afb-1a6fe3469d6e",
+          source: "https://authsignal.com",
+          time: "2025-02-20T01:51:56.070Z",
+          tenantId: "7752d28e-e627-4b1b-bb81-b45d68d617bc",
+          type: "action.log_created",
+          record: {
+            userId: "b9f74d36-fcfc-4efc-87f1-3664ab5a7fb0",
+            customVariables: {journeyType: "accountRecovery"},
+          },
+        },
+      ],
+    });
+
+    const batch = client.webhook.constructLogEventBatch(payload, createSignature(payload));
+
+    expect(batch.records).toHaveLength(1);
+    expect(batch.records[0].record.customVariables).toEqual({journeyType: "accountRecovery"});
+  });
+
+  test("test log event batch passed to construct event", () => {
+    const payload = JSON.stringify({records: []});
+
+    expect(() => client.webhook.constructEvent(payload, createSignature(payload))).toThrow(
+      "Use constructLogEventBatch instead."
+    );
+  });
+
+  test("test invalid payload", () => {
+    const payload = "not-json";
+
+    expect(() => client.webhook.constructEvent(payload, createSignature(payload))).toThrow(
+      "Payload format is invalid."
+    );
   });
 });


### PR DESCRIPTION
### Breaking Changes

- Change `WebhookEventData` from `Record<string, string>` to `Record<string, unknown>`.
- Consumers must narrow or cast webhook values before using them.

### New Features

- Support structured `customVariables`.
- Add log event batch construction and payload validation.

### Bug Fixes

- Prevent log event batches from being parsed as single events.

### Checklist

- [x] Version bumped to 3.0.0
- [ ] Documentation updated — N/A
